### PR TITLE
Fix ci failure

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   test_and_lint:
     runs-on: ubuntu-latest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,6 +23,8 @@ jobs:
 
     - name: Install dependencies
       run: |+
+        sudo apt-get update
+        sudo apt-get install -y portaudio19-dev
         python -m pip install --upgrade pip
         pip install flake8 pytest
         [ -f requirements.txt ] && pip install -r requirements.txt


### PR DESCRIPTION
- Fix CI failing at "Install dependencies" step [here](https://github.com/42Angouleme/robot-python/actions/runs/5928018059/job/16072738348)
- Add OPENAI_API_KEY secret token as env variable in CI, anticipating future pytest using it. Note that we should be careful when running paid API in CI.